### PR TITLE
Improve mobile layout of summary stats

### DIFF
--- a/src/components/SummaryStats.tsx
+++ b/src/components/SummaryStats.tsx
@@ -16,7 +16,7 @@ interface SummaryStatsProps {
 
 const SummaryStats: React.FC<SummaryStatsProps> = ({ stats }) => {
   return (
-    <div className="grid grid-cols-2 gap-3 sm:gap-4">
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 sm:gap-4">
       <Card className="bg-green-50 border-green-200">
         <CardContent className="p-3 sm:p-4 text-center">
           <div className="text-xl sm:text-2xl font-bold text-green-700">{stats.successfulDays}</div>


### PR DESCRIPTION
## Summary
- make summary stats grid single column on small screens

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68534f8774c08327a72987e23357bfbf